### PR TITLE
I18n translate possible by override the `validate.translate` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,18 @@ $ npm install parameter --save
 - `validate.addRule(type, check)` - add custom rules.
    - `type` - rule type, required and must be string type.
    - `check` - check handler. can be a `function` or a `RegExp`.
+- `validate.translate` - You can override the `translate` method to implement I18n.
 
 ### Example
 
 ```js
 var validate = require('parameter');
+
+validate.translate = function() {
+  var args = Array.prototype.slice.call(arguments);
+  // Assume there have I18n.t method for convert language.
+  return I18n.t.apply(I18n, args);
+}
 
 var data = {
   name: 'foo',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -15,6 +15,7 @@
  */
 
 var should = require('should');
+var util = require('util');
 var validate = require('..');
 
 describe('parameter', function () {
@@ -572,6 +573,21 @@ describe('parameter', function () {
       var rule = {key: 'prefix'};
       var value = {key: 'not-prefixed'};
       validate(rule, value)[0].message.should.equal('key should match /^prefix/');
+    });
+  });
+
+  describe('custom translate function', function(){
+    it('should work', function(){
+      var newValidate = require('..');
+      newValidate.translate = function() {
+        var args = Array.prototype.slice.call(arguments);
+        args[0] = args[0] + '-add.';
+        return util.format.apply(util, args);
+      };
+      var rule = { name: 'string' };
+      var error = newValidate(rule, {})[0];
+      error.message.should.equal('name required-add.');
+      error.code.should.equal('missing_field-add.');
     });
   });
 });


### PR DESCRIPTION
with #9

When the users want custom the validate messages, they can through override the `validate.translate` to done that.

```js
var validate = require('parameter');

validate.translate = function() {
  var args = Array.prototype.slice.call(arguments);
  // Assume there have I18n.t method for convert language.
  return I18n.t.apply(this, args);
}
```