### PR TITLE
feat: Add option.validateRoot to enable validate the root object

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ $ npm install parameter --save
 
 - `constructor([options])` - new Class `Parameter` instance
   - `options.translate` - translate function
+  - `options.validateRoot` - config whether to validate the passed in value must be a object.
 - `validate(rule, value)` - validate the `value` conforms to `rule`. return an array of errors if break rule.
 - `addRule(type, check)` - add custom rules.
    - `type` - rule type, required and must be string type.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ var parameter = new Parameter({
     var args = Array.prototype.slice.call(arguments);
     // Assume there have I18n.t method for convert language.
     return I18n.t.apply(I18n, args);
-  }
+  },
+  validateRoot: true, // restrict the being validate value must be a object
 });
 
 var data = {

--- a/index.js
+++ b/index.js
@@ -52,6 +52,14 @@ class Parameter {
       throw new TypeError('need object type rule');
     }
 
+    if (typeof obj !== 'object' || !obj) {
+      return [{
+        message: 'the validated value should be a object',
+        code: this.t('invalid'),
+        field: undefined,
+      }];
+    }
+
     var self = this;
 
     var errors = [];

--- a/index.js
+++ b/index.js
@@ -29,6 +29,10 @@ class Parameter {
     if (typeof opts.translate === 'function') {
       this.translate = opts.translate;
     }
+
+    if (opts.validateRoot) {
+      this.validateRoot = true;
+    }
   }
 
   t() {
@@ -52,7 +56,7 @@ class Parameter {
       throw new TypeError('need object type rule');
     }
 
-    if (typeof obj !== 'object' || !obj) {
+    if (this.validateRoot && (typeof obj !== 'object' || !obj)) {
       return [{
         message: 'the validated value should be a object',
         code: this.t('invalid'),

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -47,6 +47,12 @@ describe('parameter', function () {
   });
 
   describe('validate', function () {
+    it('should not pass when received a invalid value', function () {
+        var value = null;
+        var rule = {int: {type: 'int1', required: false}};
+        parameter.validate(rule, value)[0].message.should.equal('the validated value should be a object');;
+    });
+
     it('should invalid type throw', function () {
       (function () {
         var value = {int: 1.1};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -17,6 +17,10 @@ var util = require('util');
 var Parameter = require('..');
 var parameter = new Parameter();
 
+var parameterWithRootValidate = new Parameter({
+  validateRoot: true,
+});
+
 describe('parameter', function () {
   describe('required', function () {
     it('should required work fine', function () {
@@ -47,10 +51,16 @@ describe('parameter', function () {
   });
 
   describe('validate', function () {
-    it('should not pass when received a invalid value', function () {
+    it('should throw error when received a non object', function () {
         var value = null;
         var rule = {int: {type: 'int1', required: false}};
-        parameter.validate(rule, value)[0].message.should.equal('the validated value should be a object');;
+        let err;
+        try {
+          parameter.validate(rule, undefined)
+        } catch (e) {
+          err = e;
+        }
+      should(err.message).equal("Cannot read property 'hasOwnProperty' of undefined");
     });
 
     it('should invalid type throw', function () {
@@ -666,5 +676,14 @@ describe('parameter', function () {
       error.code.should.equal('missing_field-add.');
       error.field.should.equal('name');
     });
+  });
+});
+
+
+describe('validate with option.validateRoot', function () {
+  it('should not pass when received a invalid value', function () {
+    var value = null;
+    var rule = { int: { type: 'int1', required: false } };
+    parameterWithRootValidate.validate(rule, value)[0].message.should.equal('the validated value should be a object');;
   });
 });


### PR DESCRIPTION
## Problem
```
var rule = {
  name: 'string',
  age: 'int',
  gender: ['male', 'female', 'unknown']
};
function foo(param) {
  var errors = parameter.validate(rule, param); 
  if (errors) {
      return {
         success: false,
         errorMsg: 'param illegal',
      };
   }
}

var fooDataFromBarCallers = null;
foo(fooDataFromBarCallers)
//  users expect to receive a not passed validate result here,  bot got a exception
```