### PR TITLE
value is null should not validate

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ class Parameter {
       var rule = formatRule(rules[key]);
       var has = obj.hasOwnProperty(key);
 
-      if (!has) {
+      if (obj[key] === null || !has) {
         if (rule.required !== false) {
           errors.push({
             message: this.t('required'),


### PR DESCRIPTION
I have the problem.

I want to set some value to null.
but it throw an error.

`const rule = { transferDate: {type: 'string', required: false, allowEmpty: true}}`

`let someData = {transferDate: '2018-07-02'}`

`req.body = {transferDate: null}`

`{ message: 'should be a string', code: 'invalid', field: 'transferDate' }`