### PR TITLE
refactor: make rules more practical

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,10 @@ var errors = parameter.validate(rule, data);
 
 #### common rule
 
-- `required` - if `required` is set to false, this property can be empty. default to `true`.
+- `required` - if `required` is set to false, this property can be null or undefined. default to `true`.
 - `type` - The type of property, every type has it's own rule for the validate.
+
+__ Note: you can combile require and type end with a notation `?` like: `int?` or `string?` to specific both type and non-required.__
 
 #### int
 
@@ -122,7 +124,7 @@ Alias to `boolean`
 
 If type is `string`, there has four addition rules:
 
-- `allowEmpty`(alias to `empty`) - allow empty string, default to false.
+- `allowEmpty`(alias to `empty`) - allow empty string, default to false. If `rule.required` set to false, `allowEmpty` will be set to `true` by default.
 - `format` - A `RegExp` to check string's format.
 - `max` - The maximum length of the string.
 - `min` - The minimum length of the string.
@@ -169,6 +171,7 @@ If type is `array`, there has four addition rule:
 #### abbr
 
 - `'int'` => `{type: 'int', required: true}`
+- `'int?'` => `{type: 'int', required: false }`
 - `'integer'` => `{type: 'integer', required: true}`
 - `'number'` => `{type: 'number', required: true}`
 - `'date'` => `{type: 'date', required: true}`

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ npm install parameter --save
 - `constructor([options])` - new Class `Parameter` instance
   - `options.translate` - translate function
   - `options.validateRoot` - config whether to validate the passed in value must be a object, default to `false`.
-  - `options.convertType` - convert params to specific type, default to `false`.
+  - `options.convertType` - convert primitive params to specific type, default to `false`.
 - `validate(rule, value)` - validate the `value` conforms to `rule`. return an array of errors if break rule.
 - `addRule(type, check)` - add custom rules.
    - `type` - rule type, required and must be string type.
@@ -78,7 +78,7 @@ var errors = parameter.validate(rule, data);
 - `type` - The type of property, every type has it's own rule for the validate.
 - `convertType` - Let parameter to convert the input param to the specific type, support `int`, `number`, `string` and `boolean`, also support a function to customize your own convert method.
 
-if `options.convertType` was set to parameter's constructor, the default rules below will convert the params to matched type.
+if `options.convertType` was set to parameter's constructor, the default rules below will convert the primitive params to matched type.
 
 __ Note: you can combile require and type end with a notation `?` like: `int?` or `string?` to specific both type and non-required.__
 

--- a/README.md
+++ b/README.md
@@ -33,11 +33,13 @@ $ npm install parameter --save
 - `constructor([options])` - new Class `Parameter` instance
   - `options.translate` - translate function
   - `options.validateRoot` - config whether to validate the passed in value must be a object, default to `false`.
-  - `options.convertType` - convert primitive params to specific type, default to `false`.
+  - `options.convert` - convert primitive params to specific type, default to `false`.
 - `validate(rule, value)` - validate the `value` conforms to `rule`. return an array of errors if break rule.
 - `addRule(type, check)` - add custom rules.
    - `type` - rule type, required and must be string type.
    - `check` - check handler. can be a `function` or a `RegExp`.
+
+__Note: when `options.convert` enabled, all built-in rules check for primitive input param and convert it to rule's default `convertType`(which defined below), you can also enable this feature for specific rule by `convertType` options in each rule definition.__
 
 ### Example
 
@@ -76,11 +78,9 @@ var errors = parameter.validate(rule, data);
 
 - `required` - if `required` is set to false, this property can be null or undefined. default to `true`.
 - `type` - The type of property, every type has it's own rule for the validate.
-- `convertType` - Let parameter to convert the input param to the specific type, support `int`, `number`, `string` and `boolean`, also support a function to customize your own convert method.
+- `convertType` - Make parameter convert the input param to the specific type, support `int`, `number`, `string` and `boolean`, also support a function to customize your own convert method.
 
-if `options.convertType` was set to parameter's constructor, the default rules below will convert the primitive params to matched type.
-
-__ Note: you can combile require and type end with a notation `?` like: `int?` or `string?` to specific both type and non-required.__
+__Note: you can combile require and type end with a notation `?` like: `int?` or `string?` to specific both type and non-required.__
 
 #### int
 
@@ -90,6 +90,8 @@ If type is `int`, there has tow addition rules:
 - `min` - The minimum of the value, `value` must >= `min`.
 
 Default `convertType` is `int`.
+
+__Note: default `convertType` will only work when `options.convert` set to true in parameter's constructor.__
 
 #### integer
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ $ npm install parameter --save
 
 - `constructor([options])` - new Class `Parameter` instance
   - `options.translate` - translate function
-  - `options.validateRoot` - config whether to validate the passed in value must be a object.
+  - `options.validateRoot` - config whether to validate the passed in value must be a object, default to `false`.
+  - `options.convertType` - convert params to specific type, default to `false`.
 - `validate(rule, value)` - validate the `value` conforms to `rule`. return an array of errors if break rule.
 - `addRule(type, check)` - add custom rules.
    - `type` - rule type, required and must be string type.
@@ -75,6 +76,9 @@ var errors = parameter.validate(rule, data);
 
 - `required` - if `required` is set to false, this property can be null or undefined. default to `true`.
 - `type` - The type of property, every type has it's own rule for the validate.
+- `convertType` - Let parameter to convert the input param to the specific type, support `int`, `number`, `string` and `boolean`, also support a function to customize your own convert method.
+
+if `options.convertType` was set to parameter's constructor, the default rules below will convert the params to matched type.
 
 __ Note: you can combile require and type end with a notation `?` like: `int?` or `string?` to specific both type and non-required.__
 
@@ -84,6 +88,8 @@ If type is `int`, there has tow addition rules:
 
 - `max` - The maximum of the value, `value` must <= `max`.
 - `min` - The minimum of the value, `value` must >= `min`.
+
+Default `convertType` is `int`.
 
 #### integer
 
@@ -96,13 +102,19 @@ If type is `number`, there has tow addition rules:
 - `max` - The maximum of the value, `value` must <= `max`.
 - `min` - The minimum of the value, `value` must >= `min`.
 
+Default `convertType` is `number`.
+
 #### date
 
 The `date` type want to match `YYYY-MM-DD` type date string.
 
+Default `convertType` is `string`.
+
 #### dateTime
 
 The `dateTime` type want to match `YYYY-MM-DD HH:mm:ss` type date string.
+
+Default `convertType` is `string`.
 
 #### datetime
 
@@ -112,9 +124,13 @@ Alias to `dateTime`.
 
 The `id` type want to match `/^\d+$/` type date string.
 
+Default `convertType` is `string`.
+
 #### boolean
 
 Match `boolean` type value.
+
+Default `convertType` is `boolean`.
 
 #### bool
 
@@ -129,11 +145,15 @@ If type is `string`, there has four addition rules:
 - `max` - The maximum length of the string.
 - `min` - The minimum length of the string.
 
+Default `convertType` is `string`.
+
 #### email
 
 The `email` type want to match [RFC 5322](http://tools.ietf.org/html/rfc5322#section-3.4) email address.
 
 - `allowEmpty` - allow empty string, default is false.
+
+Default `convertType` is `string`.
 
 #### password
 
@@ -143,9 +163,13 @@ The `password` type want to match `/^$/` type string.
 - `max` - The maximum length of the password.
 - `min` - The minimum length of the password, default is 6.
 
+Default `convertType` is `string`.
+
 #### url
 
 The `url` type want to match [web url](https://gist.github.com/dperini/729294).
+
+Default `convertType` is `string`.
 
 #### enum
 
@@ -187,9 +211,9 @@ If type is `array`, there has four addition rule:
 - `[1, 2]` => `{type: 'enum', values: [1, 2]}`
 - `/\d+/` => `{type: 'string', required: true, allowEmpty: false, format: /\d+/}`
 
-## `errors` examples
+### `errors` examples
 
-### `code: missing_field`
+#### `code: missing_field`
 
 ```js
 {
@@ -199,7 +223,7 @@ If type is `array`, there has four addition rule:
 }
 ```
 
-### `code: invalid`
+#### `code: invalid`
 
 ```js
 {
@@ -209,7 +233,7 @@ If type is `array`, there has four addition rule:
 }
 ```
 
-## Release process
+### Release process
 
 We're using [semantic-release](https://github.com/semantic-release/semantic-release) to run npm publish
 after every commit on master.

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ class Parameter {
     }
 
     if (opts.validateRoot) this.validateRoot = true;
-    if (opts.convert) this.convert = true;
+    if (opts.convert) this.convertType = true;
   }
 
   t() {
@@ -69,7 +69,8 @@ class Parameter {
 
     for (var key in rules) {
       var rule = formatRule(rules[key]);
-      var has = obj[key] !== null && obj[key] !== undefined;
+      var value = obj[key];
+      var has = value !== null && value !== undefined;
 
       if (!has) {
         if (rule.required !== false) {
@@ -88,7 +89,7 @@ class Parameter {
           ', but the following type was passed: ' + rule.type);
       }
 
-      convert(rule, obj, key, this.convert);
+      convert(rule, obj, key, this.convertType);
       var msg = checker.call(self, rule, obj[key], obj);
       if (typeof msg === 'string') {
         errors.push({
@@ -237,6 +238,8 @@ function convert(rule, obj, key, defaultConvert) {
   if (!convertType) return;
 
   const value = obj[key];
+  // convert type only work for primitive data
+  if (typeof value === 'object') return;
 
   // convertType support function
   if (typeof convertType === 'function') {

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ class Parameter {
     }
 
     if (opts.validateRoot) this.validateRoot = true;
-    if (opts.convert) this.convertType = true;
+    if (opts.convert) this.convert = true;
   }
 
   t() {
@@ -89,7 +89,7 @@ class Parameter {
           ', but the following type was passed: ' + rule.type);
       }
 
-      convert(rule, obj, key, this.convertType);
+      convert(rule, obj, key, this.convert);
       var msg = checker.call(self, rule, obj[key], obj);
       if (typeof msg === 'string') {
         errors.push({

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -802,6 +802,15 @@ describe('validate with options.convert', function() {
     value.int.should.equal('123');
   });
 
+  it('should convertType not work with object', () => {
+    var value = { int: {} };
+    var res = parameterWithConvert.validate({
+      int: 'int',
+    }, value);
+    res[0].message.should.equal('should be an integer');
+    value.int.should.eql({});
+  });
+
   it('should convertType support function', () => {
     var value = { int: 'x' };
     var res = parameterWithConvert.validate({

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -27,6 +27,19 @@ describe('parameter', function () {
       should.not.exist(parameter.validate(rule, {}));
     });
 
+    it('should not required work fine with null', function () {
+      var value = { int: 1 };
+      var rule = { int: { type: 'int', required: false } };
+      should.not.exist(parameter.validate(rule, { int: null }));
+    });
+
+    it('should not required work fine with ?', function () {
+      var rule = { int: 'int?' };
+      should.not.exist(parameter.validate(rule, {}));
+      rule = { int: { type: 'int?' }};
+      should.not.exist(parameter.validate(rule, {}));
+    });
+
     it('should not required check ok', function () {
       var value = {int: 1.1};
       var rule = {int: {type: 'int', required: false}};
@@ -48,7 +61,7 @@ describe('parameter', function () {
         } catch (e) {
           err = e;
         }
-      should(err.message).equal("Cannot read property 'hasOwnProperty' of undefined");
+      should(err.message).equal('Cannot read property \'int\' of undefined');
     });
 
     it('should invalid type throw', function () {
@@ -182,6 +195,12 @@ describe('parameter', function () {
     it('should check allowEmpty with min and max ok', function () {
       var value = {string: ''};
       var rule = {string: { type: 'string', min: 10, max: 100, allowEmpty: true}};
+      should.not.exist(parameter.validate(rule, value));
+    });
+
+    it('should allowEmpty default to true if required is false', function () {
+      var value = { string: '' };
+      var rule = { string: { type: 'string', format: /\d+/, required: false } };
       should.not.exist(parameter.validate(rule, value));
     });
   });
@@ -697,6 +716,17 @@ describe('parameter', function () {
       var rule = {key: 'prefix2'};
       var value = {key: 'not-prefixed'};
       parameter.validate(rule, value)[0].message.should.equal('should match /^prefix/');
+    });
+
+    it('should add work with required false by ?', function () {
+      parameter.addRule('prefix', function (rule, value) {
+        if (value.indexOf(rule.prefix) !== 0) {
+          return 'should start with ' + rule.prefix;
+        }
+      });
+      should.not.exist(parameter.validate({ foo: 'prefix?' }, {}));
+      parameter.validate({ foo: { type: 'prefix', prefix: 'hello' } }, {})[0].message.should.equal('required');
+      parameter.validate({ foo: { type: 'prefix', prefix: 'hello' } }, { foo: 'world' })[0].message.should.equal('should start with hello');
     });
   });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,6 +9,10 @@ var parameterWithRootValidate = new Parameter({
   validateRoot: true,
 });
 
+var parameterWithConvert = new Parameter({
+  convert: true,
+});
+
 describe('parameter', function () {
   describe('required', function () {
     it('should required work fine', function () {
@@ -755,5 +759,62 @@ describe('validate with option.validateRoot', function () {
     var value = null;
     var rule = { int: { type: 'int1', required: false } };
     parameterWithRootValidate.validate(rule, value)[0].message.should.equal('the validated value should be a object');;
+  });
+});
+
+describe('validate with options.convert', function() {
+  it('should convert to specific type by default', () => {
+    var value = {
+      int: '1.1',
+      number: '1.23',
+      string: 123,
+      boolean: 'foo',
+      regexp: 567,
+      id: 888,
+    };
+    parameterWithConvert.validate({
+      int: 'int',
+      number: 'number',
+      string: 'string',
+      boolean: 'boolean',
+      regexp: /\d+/,
+      id: 'id',
+    }, value);
+    value.should.eql({
+      int: 1,
+      number: 1.23,
+      string: '123',
+      boolean: true,
+      regexp: '567',
+      id: '888'
+    });
+  });
+
+  it('should convertType support customize', () => {
+    var value = { int: 123 };
+    var res = parameterWithConvert.validate({
+      int: {
+        type: 'int',
+        convertType: 'string',
+      },
+    }, value);
+    res[0].message.should.equal('should be an integer');
+    value.int.should.equal('123');
+  });
+
+  it('should convertType support function', () => {
+    var value = { int: 'x' };
+    var res = parameterWithConvert.validate({
+      int: {
+        type: 'int',
+        convertType(v, obj) {
+          obj.should.equal(value);
+          if (v === 'x') return 1;
+          return 0;
+        },
+      },
+    }, value);
+    should.not.exist(res);
+    value.int.should.equal(1);
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -790,6 +790,39 @@ describe('validate with options.convert', function() {
     });
   });
 
+  it('should convert to boolean', () => {
+    var value = {
+      a: '0',
+      b: '',
+      c: 0,
+      d: 1,
+      e: 'false',
+      f: 'true',
+      g: true,
+      h: false,
+    };
+    parameterWithConvert.validate({
+      a: 'boolean',
+      b: 'boolean',
+      c: 'boolean',
+      d: 'boolean',
+      e: 'boolean',
+      f: 'boolean',
+      g: 'boolean',
+      h: 'boolean',
+    }, value);
+    value.should.eql({
+      a: true,
+      b: false,
+      c: false,
+      d: true,
+      e: true,
+      f: true,
+      g: true,
+      h: false,
+    });
+  });
+
   it('should convertType support customize', () => {
     var value = { int: 123 };
     var res = parameterWithConvert.validate({


### PR DESCRIPTION
- support `int?`, `string?` to express both type and non-required
- support `convertType` to empower parameter convert params to specific type
- [BREAKING] undefined and null will pass `required: false` check
- [BREAKING] string rule's allowEmpty will set to true if required set to false