### PR TITLE
fix: error message on max and min

### DIFF
--- a/index.js
+++ b/index.js
@@ -316,11 +316,11 @@ function checkInt(rule, value) {
   }
 
   if (rule.hasOwnProperty('max') && value > rule.max) {
-    return this.t('should smaller than %s', rule.max);
+    return this.t('should not bigger than %s', rule.max);
   }
 
   if (rule.hasOwnProperty('min') && value < rule.min) {
-    return this.t('should bigger than %s', rule.min);
+    return this.t('should not smaller than %s', rule.min);
   }
 }
 
@@ -342,10 +342,10 @@ function checkNumber(rule, value) {
     return this.t('should be a number');
   }
   if (rule.hasOwnProperty('max') && value > rule.max) {
-    return this.t('should smaller than %s', rule.max);
+    return this.t('should not bigger than %s', rule.max);
   }
   if (rule.hasOwnProperty('min') && value < rule.min) {
-    return this.t('should bigger than %s', rule.min);
+    return this.t('should not smaller than %s', rule.min);
   }
 }
 
@@ -385,10 +385,10 @@ function checkString(rule, value) {
   }
 
   if (rule.hasOwnProperty('max') && value.length > rule.max) {
-    return this.t('length should smaller than %s', rule.max);
+    return this.t('length should not bigger than %s', rule.max);
   }
   if (rule.hasOwnProperty('min') && value.length < rule.min) {
-    return this.t('length should bigger than %s', rule.min);
+    return this.t('length should not smaller than %s', rule.min);
   }
 
   if (rule.format && !rule.format.test(value)) {
@@ -582,10 +582,10 @@ function checkArray(rule, value) {
   }
 
   if (rule.hasOwnProperty('max') && value.length > rule.max) {
-    return this.t('length should smaller than %s', rule.max);
+    return this.t('length should not bigger than %s', rule.max);
   }
   if (rule.hasOwnProperty('min') && value.length < rule.min) {
-    return this.t('length should bigger than %s', rule.min);
+    return this.t('length should not smaller than %s', rule.min);
   }
 
   if (!rule.itemType) {


### PR DESCRIPTION
当检查`min`,`max`或者数组长度，字符串长度时，提示信息对于边界的描述并不准确，没有考虑等于关系