### PR TITLE
Dev

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,16 @@ class Parameter {
       }];
     }
 
+    if (rules._strict.required) {
+      const okeys = Object.keys(obj);
+      for (let i = 0 ; i < okeys.length; i++) {
+        if (!(okeys[i] in rules)) {
+          throw new TypeError('not declared as incoming parameters');
+        }
+      }
+    }
+    delete rules._strict;
+
     var self = this;
 
     var errors = [];

--- a/index.js
+++ b/index.js
@@ -67,21 +67,7 @@ class Parameter {
     var self = this;
 
     var errors = [];
-
-    if (rules._strict && rules._strict.required) {
-      var okeys = Object.keys(obj);
-      for (let i = 0 ; i < okeys.length; i++) {
-        if (!(okeys[i] in rules)) {
-          errors.push({
-            message: this.t('required'),
-            field: this.t(okeys[i]),
-            code: this.t('not declared as incoming parameters')
-          });
-        }
-      }
-    }
-    delete rules._strict;
-
+    
     for (var key in rules) {
       var rule = formatRule(rules[key]);
       var value = obj[key];

--- a/index.js
+++ b/index.js
@@ -67,7 +67,21 @@ class Parameter {
     var self = this;
 
     var errors = [];
-    
+
+    if (rules._strict && rules._strict.required) {
+      var okeys = Object.keys(obj);
+      for (let i = 0 ; i < okeys.length; i++) {
+        if (!(okeys[i] in rules)) {
+          errors.push({
+            message: this.t('required'),
+            field: this.t(okeys[i]),
+            code: this.t('not declared as incoming parameters')
+          });
+        }
+      }
+    }
+    delete rules._strict;
+
     for (var key in rules) {
       var rule = formatRule(rules[key]);
       var value = obj[key];

--- a/index.js
+++ b/index.js
@@ -64,19 +64,23 @@ class Parameter {
       }];
     }
 
-    if (rules._strict.required) {
+    var self = this;
+
+    var errors = [];
+
+    if (rules._strict && rules._strict.required) {
       const okeys = Object.keys(obj);
       for (let i = 0 ; i < okeys.length; i++) {
         if (!(okeys[i] in rules)) {
-          throw new TypeError('not declared as incoming parameters');
+          errors.push({
+            message: this.t('required'),
+            field: this.t(okeys[i]),
+            code: this.t('not declared as incoming parameters')
+          });
         }
       }
     }
     delete rules._strict;
-
-    var self = this;
-
-    var errors = [];
 
     for (var key in rules) {
       var rule = formatRule(rules[key]);

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ class Parameter {
     var errors = [];
 
     if (rules._strict && rules._strict.required) {
-      const okeys = Object.keys(obj);
+      var okeys = Object.keys(obj);
       for (let i = 0 ; i < okeys.length; i++) {
         if (!(okeys[i] in rules)) {
           errors.push({


### PR DESCRIPTION
添加严格校验规则，当用户传入rules中包含有_strict项，且_strict的required的值为true时，则校验：
传入参数是否包含不在rules中的参数，如果是，则提示错误‘not declared as incoming parameters’（擦混入参数包含为定义的参数项）
![image](https://user-images.githubusercontent.com/26812703/65133202-d187c000-da34-11e9-8408-26e859d04d05.png)
