### PR TITLE
support convert object

### DIFF
--- a/index.js
+++ b/index.js
@@ -271,13 +271,15 @@ function convert(rule, obj, key, defaultConvert) {
   if (!convertType) return;
 
   const value = obj[key];
-  // convert type only work for primitive data
-  if (typeof value === 'object') return;
-
+  
+  // if set convertType function it should be support convert object
   // convertType support function
   if (typeof convertType === 'function') {
     obj[key] = convertType(value, obj);
     return;
+  }else{
+    // default convert type only work for primitive data
+    if (typeof value === 'object') return;
   }
 
   switch (convertType) {


### PR DESCRIPTION
项目使用egg开发，使用内置的egg-validate作为参数验证，有幸接触到本项目。由于参数验证中不能使用自定义函数对对象进行转换，所以会造成一些不便。
例如前端用户get方式传递参数`{ids:[1,2,3]}`，url编码后url为 `http://xxx.com?ids[]=1&ids[]=2&ids[]=3`，后端接受到的参数`{ids:['1','2','3']}`，数组中每个项目均为字符串。此时如果使用以下验证对象会验证失败。
```javascript
const rules = {
    ids:{
        type:'array',
        itemType:'int',
    }
}
```
已经实现以下转换方式，只有在自定义convertType为函数的情况下，才支持对对向的转换。且兼容之前任何操作
```javascript
const p = new Parameter({
    convert:true
})
const data = {
    ids:['1','2','3']
}
const rules = {
    ids:{
        type:'array',
        itemType:'int',
        convertType:(val) => {
            return val.map(item => Number(item))
        },
    }
}
p.validate(rules,data)
````
